### PR TITLE
Add addBookmark cmd to marketplace extension and category context menus

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,11 +175,22 @@
           "when": "view == extensionBookmarkerView"
         }
       ],
+      "extension/context": [
+        {
+          "command": "extension-bookmarker.addBookmark",
+          "when": "sideBarFocus && activeViewlet == 'workbench.view.extensions'"
+        }
+      ],
       "view/item/context": [
         {
           "command": "extension-bookmarker.removeBookmark",
           "group": "0_extension_bookmarker",
           "when": "view == extensionBookmarkerView && viewItem == bookmarkedExtension"
+        },
+        {
+          "command": "extension-bookmarker.addBookmark",
+          "group": "1_category",
+          "when": "view == extensionBookmarkerView && (viewItem == category || viewItem == defaultCategory)"
         },
         {
           "command": "extension-bookmarker.renameCategory",


### PR DESCRIPTION
Hopefully the screencaps explain this well enough. On Marketplace Extensions it adds an 'Add Bookmark' option to the context menu that will then let you choose a category and add the bookmark to it. Somewhat similarly, for categories, it adds an 'Add Bookmark' option to the context menu and lets you enter an extension ID.

# 1. Add Bookmark from a Marketplace Extension context menu
![add-bookmark-marketplace](https://github.com/osxzxso/extension-bookmarker/assets/2822743/1f23e8e9-a623-4308-b9a5-aa89ef9e9f4c)

# 2. Add Bookmark from an Extension Bookmarker-Category context menu
![add-bookmark-category](https://github.com/osxzxso/extension-bookmarker/assets/2822743/e87b63a1-7d71-4637-a861-fb418a4bb3f4)
